### PR TITLE
Set style `overflow-y: auto` for tab content

### DIFF
--- a/src/Tabs/styles.js
+++ b/src/Tabs/styles.js
@@ -54,7 +54,7 @@ export const TabsContainer = styled.div`
 
   >div:last-child {
     flex: 1;
-    overflow-y: hidden;
+    overflow-y: auto;
     position: relative;
   }
 `;


### PR DESCRIPTION
It should can be scroll if we have longer state tree:

![2016-11-26 7 36 51](https://cloud.githubusercontent.com/assets/3001525/20636620/24fda442-b3ab-11e6-9eba-7ccc6a67b51b.png)
